### PR TITLE
Agricola: fixed issue #17

### DIFF
--- a/dist/style.css
+++ b/dist/style.css
@@ -767,6 +767,10 @@ a.tournaments-list-result .tournaments-list-result__gamemode span {
   color: black;
 }
 
+.agricola_popin_contents {
+  color: black;
+}
+
 .bgagame-azul zoom-notice {
   background-color: #2c2c2c;
 }

--- a/dist/style.css
+++ b/dist/style.css
@@ -763,7 +763,7 @@ a.tournaments-list-result .tournaments-list-result__gamemode span {
   background-image: url(https://x.boardgamearena.net/data/themereleases/current/games/agricola/211210-1652/img/left_4p.png), url(https://x.boardgamearena.net/data/themereleases/current/games/agricola/211210-1652/img/background.jpg);
 }
 
-.tundra .dijitTooltipContainer .action-header, .tundra .dijitTooltipContainer .action-desc, .tundra .dijitTooltipContainer .player-card {
+html[style^="--agricola"] .tundra .dijitTooltipContainer .action-header, html[style^="--agricola"] .tundra .dijitTooltipContainer .action-desc, html[style^="--agricola"] .tundra .dijitTooltipContainer .player-card {
   color: black;
 }
 
@@ -773,6 +773,10 @@ a.tournaments-list-result .tournaments-list-result__gamemode span {
 
 .agricola_popin_title {
   background-color: #2c2c2c !important;
+}
+
+html[style^="--agricola"] .player-card-resizable {
+  color: black !important;
 }
 
 .bgagame-azul zoom-notice {

--- a/dist/style.css
+++ b/dist/style.css
@@ -771,6 +771,10 @@ a.tournaments-list-result .tournaments-list-result__gamemode span {
   color: black;
 }
 
+.agricola_popin_title {
+  background-color: #2c2c2c !important;
+}
+
 .bgagame-azul zoom-notice {
   background-color: #2c2c2c;
 }

--- a/dist/style.css
+++ b/dist/style.css
@@ -749,6 +749,19 @@ a.tournaments-list-result .tournaments-list-result__gamemode span {
   background: url(https://x.boardgamearena.net/data/themereleases/current/games/agricola/211210-1652/img/central.png), url(https://x.boardgamearena.net/data/themereleases/current/games/agricola/211210-1652/img/background.jpg);
   background-size: 100% auto, 100% auto;
 }
+.bgagame-agricola #add-board {
+  background-image: url(https://x.boardgamearena.net/data/themereleases/current/games/agricola/211210-1652/img/add_34p.png), url(https://x.boardgamearena.net/data/themereleases/current/games/agricola/211210-1652/img/background.jpg);
+  background-size: 100% auto;
+}
+.bgagame-agricola [data-players="2"] #add-board {
+  background-image: url(https://x.boardgamearena.net/data/themereleases/current/games/agricola/211210-1652/img/add_2p.png), url(https://x.boardgamearena.net/data/themereleases/current/games/agricola/211210-1652/img/background.jpg);
+}
+.bgagame-agricola #left-board {
+  background-image: url(https://x.boardgamearena.net/data/themereleases/current/games/agricola/211210-1652/img/left_3p.png), url(https://x.boardgamearena.net/data/themereleases/current/games/agricola/211210-1652/img/background.jpg);
+}
+.bgagame-agricola [data-players="4"] #left-board {
+  background-image: url(https://x.boardgamearena.net/data/themereleases/current/games/agricola/211210-1652/img/left_4p.png), url(https://x.boardgamearena.net/data/themereleases/current/games/agricola/211210-1652/img/background.jpg);
+}
 
 .tundra .dijitTooltipContainer .action-header, .tundra .dijitTooltipContainer .action-desc, .tundra .dijitTooltipContainer .player-card {
   color: black;

--- a/dist/style.css
+++ b/dist/style.css
@@ -742,6 +742,18 @@ a.tournaments-list-result .tournaments-list-result__gamemode span {
   bottom: 1rem;
 }
 
+.bgagame-agricola .action-header, .bgagame-agricola .action-desc, .bgagame-agricola .zone-capacity, .bgagame-agricola .agricola-player-pannel, .bgagame-agricola .player-board, .bgagame-agricola .player-card {
+  color: black;
+}
+.bgagame-agricola #central-board {
+  background: url(https://x.boardgamearena.net/data/themereleases/current/games/agricola/211210-1652/img/central.png), url(https://x.boardgamearena.net/data/themereleases/current/games/agricola/211210-1652/img/background.jpg);
+  background-size: 100% auto, 100% auto;
+}
+
+.tundra .dijitTooltipContainer .action-header, .tundra .dijitTooltipContainer .action-desc, .tundra .dijitTooltipContainer .player-card {
+  color: black;
+}
+
 .bgagame-azul zoom-notice {
   background-color: #2c2c2c;
 }

--- a/src/games/agricola.scss
+++ b/src/games/agricola.scss
@@ -31,3 +31,7 @@
 .agricola_popin_contents {
 	color: black;
 }
+
+.agricola_popin_title {
+	background-color: $lightSurface!important;
+}

--- a/src/games/agricola.scss
+++ b/src/games/agricola.scss
@@ -22,7 +22,7 @@
 	}	
 }
 
-.tundra .dijitTooltipContainer {
+html[style^="--agricola"] .tundra .dijitTooltipContainer {
 	.action-header, .action-desc, .player-card {
 	   color:black;
 	}
@@ -34,4 +34,9 @@
 
 .agricola_popin_title {
 	background-color: $lightSurface!important;
+}
+
+//overlay is not in bgagame-agricola and name is a bit too generic
+html[style^="--agricola"] .player-card-resizable{
+  color: black!important;
 }

--- a/src/games/agricola.scss
+++ b/src/games/agricola.scss
@@ -6,6 +6,20 @@
 		background: url(https://x.boardgamearena.net/data/themereleases/current/games/agricola/211210-1652/img/central.png), url(https://x.boardgamearena.net/data/themereleases/current/games/agricola/211210-1652/img/background.jpg);
 		background-size: 100% auto, 100% auto;
 	}
+	#add-board {
+		background-image:url(https://x.boardgamearena.net/data/themereleases/current/games/agricola/211210-1652/img/add_34p.png), url(https://x.boardgamearena.net/data/themereleases/current/games/agricola/211210-1652/img/background.jpg);
+		background-size:100% auto;
+	}
+	[data-players="2"] #add-board {
+		background-image:url(https://x.boardgamearena.net/data/themereleases/current/games/agricola/211210-1652/img/add_2p.png), url(https://x.boardgamearena.net/data/themereleases/current/games/agricola/211210-1652/img/background.jpg);
+	} 
+	
+	#left-board {
+		background-image:url(https://x.boardgamearena.net/data/themereleases/current/games/agricola/211210-1652/img/left_3p.png), url(https://x.boardgamearena.net/data/themereleases/current/games/agricola/211210-1652/img/background.jpg);
+	 }
+	[data-players="4"] #left-board {
+		background-image:url(https://x.boardgamearena.net/data/themereleases/current/games/agricola/211210-1652/img/left_4p.png), url(https://x.boardgamearena.net/data/themereleases/current/games/agricola/211210-1652/img/background.jpg);
+	}	
 }
 
 .tundra .dijitTooltipContainer {

--- a/src/games/agricola.scss
+++ b/src/games/agricola.scss
@@ -27,3 +27,7 @@
 	   color:black;
 	}
 }
+
+.agricola_popin_contents {
+	color: black;
+}

--- a/src/games/agricola.scss
+++ b/src/games/agricola.scss
@@ -1,0 +1,15 @@
+.bgagame-agricola {
+	.action-header, .action-desc, .zone-capacity, .agricola-player-pannel, .player-board, .player-card{
+	  color:black;
+	}
+	#central-board{
+		background: url(https://x.boardgamearena.net/data/themereleases/current/games/agricola/211210-1652/img/central.png), url(https://x.boardgamearena.net/data/themereleases/current/games/agricola/211210-1652/img/background.jpg);
+		background-size: 100% auto, 100% auto;
+	}
+}
+
+.tundra .dijitTooltipContainer {
+	.action-header, .action-desc, .player-card {
+	   color:black;
+	}
+}

--- a/src/style.scss
+++ b/src/style.scss
@@ -505,6 +505,7 @@ input.dijitInputInner {
 @import "versioning";
 
 // Specific games
+@import "games/agricola";
 @import "games/azul";
 @import "games/bang";
 @import "games/cacao";


### PR DESCRIPTION
fixed issue #17

Set the pasture background image on the central board only, since it was not clearly readable, while other boards are clear enough in my opinion.
![image](https://user-images.githubusercontent.com/598526/148639882-963e6b50-a966-45ef-8490-67889ad86a20.png)
