### PR TITLE
Fix narrow window menu bar

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -20,7 +20,8 @@ body {
     }
 }
 
-.bga-menu-bar {
+.bga-menu-bar,
+.bga-menu-subbar {
 	background-image:linear-gradient($lighterSurface ,$surface)!important;
 }
 .bga-link {


### PR DESCRIPTION
When you narrow the window, the menu bar gets replaced with a different, lower menu "subbar" which has not been darkened in this codebase yet. This change darkens the subbar as well.