### PR TITLE
Fix tooltip used in games such as Space Base

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -153,6 +153,10 @@ input.dijitInputInner {
     color : black;
 }
 
+.cardToolTip {
+    background-color: $lighterSurface !important;
+}
+
 .post .comment {
     background : $lightSurface
 }


### PR DESCRIPTION
The hover tool tip widget used in some games such as Space Base renders with a white background. It has a different html structure than tool tips in some other games, but is not contained in the DOM by any game-specific wrapper element.