### PR TITLE
Make wait time visible on Play Now screen

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -404,6 +404,9 @@ input.dijitInputInner {
     box-shadow: none;
     border: none;
 }
+.wannaplayauto_time {
+    color: white;
+}
 
 .tabbed_slider_bar_barcenter {
     background-color: $lightSurface !important;


### PR DESCRIPTION
On the Play Now screen, when you click a game for automatic player choosing, a text timer appears on the game, telling you how long you'll wait. This change makes that timer visible in dark mode.

Before:

![2022-02-13 15_43_19-DimScreen Screen](https://user-images.githubusercontent.com/614132/153794044-1128bf57-5056-4fb0-8fb6-1b8424584869.png)

After:

![2022-02-13 15_48_08-DimScreen Screen](https://user-images.githubusercontent.com/614132/153794056-c137f6f1-87c1-4a73-a0f8-b59a329dc531.png)

