### PR TITLE
Fix #34 name visible in 7WArchitects

### DIFF
--- a/src/games/sevenwondersarchitects.scss
+++ b/src/games/sevenwondersarchitects.scss
@@ -6,4 +6,7 @@
 	.stwbattleicon {
 		color: black;
 	}
+	.stw_name_holder {
+		color: white;
+	}
 }


### PR DESCRIPTION
Make the player names readable under the wonders in 7 Wonders Architects

Before:
![2022-02-17 21_32_18-DimScreen Screen](https://user-images.githubusercontent.com/614132/154624428-138d68c3-7feb-4e81-b859-9ba4f262d0e8.png)

After:
![2022-02-17 21_39_22-DimScreen Screen](https://user-images.githubusercontent.com/614132/154624438-960f39b1-02be-4139-8f23-60479b2e7345.png)

