### PR TITLE
Fixed modal/popup background

### DIFF
--- a/src/menu.scss
+++ b/src/menu.scss
@@ -31,3 +31,15 @@
         }
     }
 }
+
+.bubblebanner{
+    background-color: $surface;
+    
+    &::after{
+        border-color: $lighterSurface;
+    }
+}
+
+.bga-popup-modal__content.svelte-1gmp0d8.svelte-1gmp0d8{
+    background-color: $surface;
+}


### PR DESCRIPTION
Hi there, I changed the background for the popup (.bubblebanner) that appears when waiting for other players that says "This is a premium game", it was yellow background with white text. As well as the modal that asks if you want to 
send an email to notify your friend when inviting him/her, was white over white.
This is my very first pull request on github so let me know if something is wrong.
Thank you for all your effort!


![Screenshot 2022-07-11 at 16 47 07](https://user-images.githubusercontent.com/93521016/178304653-98002c8f-f571-464a-8346-60798f5e77aa.jpg)
![Screenshot 2022-07-11 at 17 43 57](https://user-images.githubusercontent.com/93521016/178304657-fd15e043-933a-4817-a4e5-f8156921d936.jpg)
.