### PR TITLE
Next Station London

### DIFF
--- a/src/games/nextstationlondon.scss
+++ b/src/games/nextstationlondon.scss
@@ -1,0 +1,10 @@
+.bgagame-nextstation {
+    .nex_stationcrossed {
+        color: black;
+    }
+    .nex_metropad,
+    .nex_metropad .nex_station,
+    .nex_metropad path {
+        filter: invert(1) hue-rotate(180deg);
+    }
+}

--- a/src/games/nextstationlondon.scss
+++ b/src/games/nextstationlondon.scss
@@ -1,6 +1,7 @@
 .bgagame-nextstation {
-    .nex_stationcrossed {
-        color: black;
+    .nex_stationcrossed,
+    .nex_scorepad_values {
+         color: black;
     }
     .nex_metropad,
     .nex_metropad .nex_station,

--- a/src/games/nextstationlondon.scss
+++ b/src/games/nextstationlondon.scss
@@ -8,4 +8,10 @@
     .nex_metropad path {
         filter: invert(1) hue-rotate(180deg);
     }
+    .nex_metropad .nex_central {
+        filter: invert(0) hue-rotate(180deg) !important;
+    }
+    .nex_metropad .nex_special {
+        filter: invert(1) hue-rotate(180deg) !important;
+    }
 }


### PR DESCRIPTION
Invert white-grey background image but not colors or foreground objects, and turn X's black

Before:
![nextstationlondon-before](https://user-images.githubusercontent.com/614132/182747707-397703d0-8a3d-4d2b-bfaf-7927d300a179.png)

After:
![nextstationlondon-after](https://user-images.githubusercontent.com/614132/182747724-45442f2c-f161-4a41-89ad-5e3d66c561e4.png)

Also fixed the visibility of the subtotal and total score boxes which aren't readable when text is white:

Before:
![score-hidden](https://user-images.githubusercontent.com/614132/183283062-8ed53ff3-e1e7-421d-8c16-bbb9cc40bc2c.png)

After:
![score-visible](https://user-images.githubusercontent.com/614132/183283071-0b342df4-b092-48e3-8655-ef22115d11e0.png)

Also made the spikes of the tourist stations violet instead of yellow, and made the question mark wild card tourist station have visible spikes against the black background. No easy way to make the question mark be light mode with bright spiky edges because its graphic is constructed differently from the other spiky tourist stations.

Before:
![subtle](https://user-images.githubusercontent.com/614132/183539753-45286581-9c03-4f6d-a972-96da19762e96.png)

After:
![obvious](https://user-images.githubusercontent.com/614132/183539770-24c97fb2-9f2a-45ac-883e-b7c6f651b5c9.png)




