### PR TITLE
"Break the Code" fixes and darkening

### DIFF
--- a/src/games/breakthecode.scss
+++ b/src/games/breakthecode.scss
@@ -6,7 +6,7 @@
     }
     .scoresheet,
     .deckcardscont {
-        filter: brightness(66%);
+        filter: brightness(85%);
     }
     .card,
     .tileBACK {

--- a/src/games/breakthecode.scss
+++ b/src/games/breakthecode.scss
@@ -1,6 +1,15 @@
 .bgagame-breakthecode {
     .celltile,
+    .celltile0,
     .noteclass {
         color: black;
+    }
+    .scoresheet,
+    .deckcardscont {
+        filter: brightness(66%);
+    }
+    .card,
+    .tileBACK {
+        filter: invert(1) hue-rotate(180deg);
     }
 }


### PR DESCRIPTION
Reveal note-taking numbers in 3+ player games.
Decrease brightness on white boards (can't invert because of gameplay).
Invert clue cards to darken without changing color.

Before:
![breakthecode-before](https://user-images.githubusercontent.com/614132/182754519-9670de04-ec3f-493f-a9df-ea05e464be25.png)


After:
![breakthecode-after](https://user-images.githubusercontent.com/614132/182754551-ed215ab2-f865-4cc5-a680-ab2a2dfd1e52.png)

