### PR TITLE
Darken "Can't Stop Express" player boards

### DIFF
--- a/src/games/cantstopexpress.scss
+++ b/src/games/cantstopexpress.scss
@@ -1,0 +1,5 @@
+.bgagame-cantstopexpress {
+    .pad {
+        filter: invert(1) hue-rotate(180deg) saturate(500%);
+    }
+}


### PR DESCRIPTION
Invert white board images to black without changing hue of X's and numbers.
Saturate colors of X's and numbers to avoid washed out colors from inverting.

### Before:
![cantstopexpress-light](https://user-images.githubusercontent.com/614132/182757189-9f82aaf8-e528-487c-a05b-ada13f5e1485.png)

### After:
![cantstopexpress-dark](https://user-images.githubusercontent.com/614132/182757198-db5cc936-18b5-4ae7-8c70-ce6e0c19faaa.png)
